### PR TITLE
Update list-closed-question.php

### DIFF
--- a/inc/widgets/list-closed-question.php
+++ b/inc/widgets/list-closed-question.php
@@ -7,9 +7,9 @@ class DWQA_Closed_Question_Widget extends WP_Widget {
 	 *
 	 * @return void
 	 **/
-	function DWQA_Closed_Question_Widget() {
+	function __construct() {
 		$widget_ops = array( 'classname' => 'dwqa-widget dwqa-closed-questions', 'description' => __( 'Show a list of questions that was ordered by views.', 'dwqa' ) );
-		$this->WP_Widget( 'dwqa-closed-question', __( 'DWQA Closed Questions', 'dwqa' ), $widget_ops );
+		parent::__construct( 'dwqa-closed-question', __( 'DWQA Closed Questions', 'dwqa' ), $widget_ops );
 	}
 
 	function widget( $args, $instance ) {


### PR DESCRIPTION
PHP4-style constructors are deprecated since WordPress 4.3