### PR TITLE
Handle array for post_type

### DIFF
--- a/inc/Helptab.php
+++ b/inc/Helptab.php
@@ -31,8 +31,12 @@ class DWQA_Helptab {
 			return $current_screen->post_type;
 
 		//lastly check the post_type querystring
-		elseif ( isset( $_REQUEST['post_type'] ) )
+		elseif ( isset( $_REQUEST['post_type'] ) ) {
+			//Some plugins set post_type to an array
+			if ( is_array( $_REQUEST['post_type'] ) )
+				return null;
 			return sanitize_key( $_REQUEST['post_type'] );
+		}
 	}
 
 	private function create_tabs(){


### PR DESCRIPTION
Hello. I love your plugin.

I noticed however that for a while I've had a lot of error messages that look like this:
PHP Warning:  strtolower() expects parameter 1 to be string, array given in web/wp/wp-includes/formatting.php on line 1501

When I went to track this down, it was because the Calendarize It plugin ( http://calendarize.it/ ) likes to make requests with "post_type[]" and one or more post types in a single request. PHP turns this into an array which causes the above error when it's passed into sanitize_key() here.

I'm not too sure that making requests with post type as an array is entirely valid? However it does happen, so I thought I'd drop you a pull request to see what you thought.

Kind regards,
Shanee Vanstone.