### PR TITLE
Allow developers to register custom information in question creation

### DIFF
--- a/inc/Handle.php
+++ b/inc/Handle.php
@@ -406,6 +406,7 @@ class DWQA_Handle {
 
 					if ( apply_filters( 'dwqa-current-user-can-add-question', dwqa_current_user_can( 'post_question' ), $postarr ) ) {
 						$new_question = $this->insert_question( $postarr );
+						do_action('dwqa_after_insert_question',$new_question);
 					} else {
 						//$dwqa_submit_question_errors->add( 'submit_question',  __( 'You do not have permission to submit question.', 'dwqa' ) );
 						dwqa_add_notice( __( 'You do not have permission to submit question.', 'dwqa' ), 'error' );

--- a/templates/question-submit-form.php
+++ b/templates/question-submit-form.php
@@ -61,6 +61,7 @@
 		<?php endif; ?>
 		<?php wp_nonce_field( '_dwqa_submit_question' ) ?>
 		<?php dwqa_load_template( 'captcha', 'form' ); ?>
+		<?php do_action('dwqa_before_question_submit_button'); ?>
 		<input type="submit" name="dwqa-question-submit" value="<?php _e( 'Submit', 'dwqa' ) ?>" >
 	</form>
 	<?php do_action( 'dwqa_after_question_submit_form' ); ?>


### PR DESCRIPTION
I have added two small hooks, one in the question form and another in the question insertion which would allow developers to register custom information.