### PR TITLE
*If post is empty, return $display_name

### DIFF
--- a/inc/User.php
+++ b/inc/User.php
@@ -149,6 +149,9 @@ function dwqa_is_followed( $post_id = false, $user_id = false ) {
 function dwqa_the_author( $display_name ) {
 	global $post;
 
+	if ( empty( $post ) ) {
+		return $display_name;
+	}
 	if ( 'dwqa-answer' == $post->post_type || 'dwqa-question' == $post->post_type) {
 		if ( dwqa_is_anonymous( $post->ID ) ) {
 			$anonymous_name = get_post_meta( $post->ID, '_dwqa_anonymous_name', true );


### PR DESCRIPTION
`$post` is assumed to exist, but may be empty.

See https://www.designwall.com/question/bug-incuser-php/.