### PR TITLE
Restructured filter for better performance

### DIFF
--- a/inc/helper/plugin-compatibility.php
+++ b/inc/helper/plugin-compatibility.php
@@ -13,19 +13,19 @@ function dwqa_advanced_ads_select_args( $args ) {
 /** Facebook Comments **/
 add_filter( 'get_post_metadata', 'dwqa_disable_wpdevart_facebook_comment', 10, 3 );
 function dwqa_disable_wpdevart_facebook_comment( $value, $post_id, $meta_key ) {
+	if ('_disabel_wpdevart_facebook_comment' != $meta_key) {
+		return $value;
+	}
+	
 	$dwqa_options = get_option( 'dwqa_options', array() );
-	if ( 
-			'_disabel_wpdevart_facebook_comment' == $meta_key
-			&& 
-			( 
-				'dwqa-question' == get_post_type( $post_id ) // is single question
-				|| 
-				'dwqa-answer' == get_post_type( $post_id ) // is single answer
-				||
-				(int) $dwqa_options['pages']['submit-question'] == (int) $post_id // is submit question page
-				||
-				(int) $dwqa_options['pages']['archive-question'] == (int) $post_id // is archive page
-			)
+	if (
+		'dwqa-question' == get_post_type( $post_id ) // is single question
+		|| 
+		'dwqa-answer' == get_post_type( $post_id ) // is single answer
+		||
+		(int) $dwqa_options['pages']['submit-question'] == (int) $post_id // is submit question page
+		||
+		(int) $dwqa_options['pages']['archive-question'] == (int) $post_id // is archive page
 		) {
 		$value = 'disable';
 	}


### PR DESCRIPTION
I was profiling my website and tracked back a performance issue to this function, this modification speeds up all my page loads by 0.2s (10%).

The site I work on is quite plugin heavy and presumably makes a lot of calls to get_post_metadata. This triggers this filter which in turn makes lots of fairly slow calls to get_option (which itself checks for several more filters and calls them).

I've re-ordered the function to greatly reduce the number of calls to get_option.

I'm afraid I don't actually _know_ what this filter is for, however this change does not break/affect my website and the code certainly _looks_ equivalent.

I'm sure that most websites don't have as many plugins or make as many calls to meta data. However, I'd very much appreciate it if you merged this change anyway, as I'm sure it will be useful to at least someone out there.

Keep up the good work on the plugin.

Kind regards and all the best,
Shanee Vanstone.